### PR TITLE
Allow more control over the regular expression

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -23,7 +23,8 @@ function passFilters_(url, type, filters) {
       switch (filter.type) {
         case 'urls':
           hasUrlFilters = true;
-          if (url.search(filter.urlRegex) == 0) {
+          let urlRegex = (filter.urlRegex.match('^/.*/[gim]*$')) ? RegExp(filter.urlRegex) : filter.urlRegex;
+          if (url.search(urlRegex) == 0) {
             allowUrls = true;
           }
           break;


### PR DESCRIPTION
In some instances it would be good to be able to specify a regex as being case insensitive. This adds checking whether the urlRegex field is in the form of a Javascript regular expression before passing it to `.search()` and converts it if so.